### PR TITLE
Fix ownership of mounted volume

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -124,6 +124,7 @@ runs:
           sudo lvcreate -l 100%FREE -n buildlv "${VG_NAME}"
           sudo mkfs.ext4 -m0 "/dev/mapper/${VG_NAME}-buildlv"
           sudo mount "/dev/mapper/${VG_NAME}-buildlv" "${BUILD_MOUNT_PATH}"
+          sudo chown -R runner "${BUILD_MOUNT_PATH}"
 
     - name: Disk space report after modification
       shell: bash


### PR DESCRIPTION
Thanks for making this! It helped me a lot to solve space issue with my project.

Yet, in my case, I had to fix ownership of the mounted volume to avoid permission error.
Otherwise, I was running into an error like this with actions/checkout@v2:

```
Error: Command failed: rm -rf "/home/runner/work/xxx/xxx/lost+found"
rm: cannot remove '/home/runner/work/xxx/xxx/lost+found': Permission denied
```