### PR TITLE
Change GID in addition to UID for mounted volume

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -153,6 +153,7 @@ runs:
           fi
           sudo mount "/dev/mapper/${VG_NAME}-buildlv" "${BUILD_MOUNT_PATH}"
           sudo chown -R runner "${BUILD_MOUNT_PATH}"
+          sudo chgrp -R runner "${BUILD_MOUNT_PATH}"
 
     - name: Disk space report after modification
       shell: bash


### PR DESCRIPTION
Thank you for creating this awesome tool! 

Currently, `${BUILD_MOUNT_PATH}` is created with group ID 0. I ran into an issue using this with a containerized build chain for embedded linux ([crops/poky](https://hub.docker.com/r/crops/poky) for the [yocto project](https://www.yoctoproject.org)) and had to change the group ID to fix it. 