### PR TITLE
Fix: Losing Workspace Files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -182,6 +182,7 @@ runs:
           sudo chown -R "${{ inputs.build-mount-path-ownership }}" "${BUILD_MOUNT_PATH}"
 
     - name: Disk space report after modification
+      shell: sh
       run: |
         echo "Memory and swap:"
         free

--- a/action.yml
+++ b/action.yml
@@ -182,7 +182,8 @@ runs:
           sudo chown -R "${{ inputs.build-mount-path-ownership }}" "${BUILD_MOUNT_PATH}"
 
     - name: Disk space report after modification
-      shell: sh
+      shell: bash
+      working-directory: /
       run: |
         echo "Memory and swap:"
         free

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ runs:
 
           # Move files in workspace to temp folder
           sudo mkdir /movedwsp
-          sudo mv -r "$BUILD_MOUNT_PATH/*" /movedwsp
+          sudo mv "$BUILD_MOUNT_PATH/*" /movedwsp
 
           echo "Creating LVM Volume."
           echo "  Creating LVM PV on root fs."
@@ -186,7 +186,7 @@ runs:
           sudo chown -R "${{ inputs.build-mount-path-ownership }}" "${BUILD_MOUNT_PATH}"
 
           # Move workspace files back
-          sudo mv -r /movedwsp/* "$BUILD_MOUNT_PATH/"
+          sudo mv /movedwsp/* "$BUILD_MOUNT_PATH/"
 
     - name: Disk space report after modification
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,7 @@ runs:
     - name: Maximize build disk space
       shell: bash
       run: |
+          cd /
           set -euo pipefail
 
           BUILD_MOUNT_PATH="${{ inputs.build-mount-path }}"
@@ -184,7 +185,6 @@ runs:
     - name: Disk space report after modification
       shell: bash
       run: |
-        cd /
         echo "Memory and swap:"
         free
         echo

--- a/action.yml
+++ b/action.yml
@@ -184,6 +184,7 @@ runs:
     - name: Disk space report after modification
       shell: bash
       run: |
+        cd /
         echo "Memory and swap:"
         free
         echo

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ runs:
 
           # Move files in workspace to temp folder
           sudo mkdir /movedwsp
-          sudo mv "$BUILD_MOUNT_PATH/*" /movedwsp
+          sudo mv $BUILD_MOUNT_PATH/* /movedwsp
 
           echo "Creating LVM Volume."
           echo "  Creating LVM PV on root fs."
@@ -186,7 +186,7 @@ runs:
           sudo chown -R "${{ inputs.build-mount-path-ownership }}" "${BUILD_MOUNT_PATH}"
 
           # Move workspace files back
-          sudo mv /movedwsp/* "$BUILD_MOUNT_PATH/"
+          sudo mv /movedwsp/* $BUILD_MOUNT_PATH/
 
     - name: Disk space report after modification
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,6 @@ runs:
     - name: Maximize build disk space
       shell: bash
       run: |
-          cd /
           set -euo pipefail
 
           BUILD_MOUNT_PATH="${{ inputs.build-mount-path }}"
@@ -183,7 +182,6 @@ runs:
           sudo chown -R "${{ inputs.build-mount-path-ownership }}" "${BUILD_MOUNT_PATH}"
 
     - name: Disk space report after modification
-      shell: bash
       run: |
         echo "Memory and swap:"
         free

--- a/action.yml
+++ b/action.yml
@@ -137,6 +137,10 @@ runs:
           sudo swapoff -a
           sudo rm -f /mnt/swapfile
 
+          # Move files in workspace to temp folder
+          mkdir /movedwsp
+          mv -r "$BUILD_MOUNT_PATH/*" /movedwsp
+
           echo "Creating LVM Volume."
           echo "  Creating LVM PV on root fs."
           # create loop pv image on root fs
@@ -181,9 +185,11 @@ runs:
           sudo mount "/dev/mapper/${VG_NAME}-buildlv" "${BUILD_MOUNT_PATH}"
           sudo chown -R "${{ inputs.build-mount-path-ownership }}" "${BUILD_MOUNT_PATH}"
 
+          # Move workspace files back
+          mv -r /movedwsp/* "$BUILD_MOUNT_PATH/"
+
     - name: Disk space report after modification
       shell: bash
-      working-directory: /
       run: |
         echo "Memory and swap:"
         free

--- a/action.yml
+++ b/action.yml
@@ -138,8 +138,8 @@ runs:
           sudo rm -f /mnt/swapfile
 
           # Move files in workspace to temp folder
-          mkdir /movedwsp
-          mv -r "$BUILD_MOUNT_PATH/*" /movedwsp
+          sudo mkdir /movedwsp
+          sudo mv -r "$BUILD_MOUNT_PATH/*" /movedwsp
 
           echo "Creating LVM Volume."
           echo "  Creating LVM PV on root fs."
@@ -186,7 +186,7 @@ runs:
           sudo chown -R "${{ inputs.build-mount-path-ownership }}" "${BUILD_MOUNT_PATH}"
 
           # Move workspace files back
-          mv -r /movedwsp/* "$BUILD_MOUNT_PATH/"
+          sudo mv -r /movedwsp/* "$BUILD_MOUNT_PATH/"
 
     - name: Disk space report after modification
       shell: bash


### PR DESCRIPTION
When you set the build-mount-path to a path that included the default workspace directory(such as ../$GITHUB_WORKSPACE), all files in the directory will be deleted, and the job will fail because of `An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/proj/proj'. No such file or directory`

This pull request solved the issue. It moves the files in the workspace directory to a temp directory, and restores it after creating the LVM volume.