### PR TITLE
Detect absence of /mnt

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -136,7 +136,11 @@ runs:
           fi
           echo "... done"
 
+          echo "Checking if /mnt is mounted..."
+          echo "Mounts:"
+          cat /proc/mounts
           mnt_exists=$(cat /proc/mounts | cut -f2 -d" " | grep "^/mnt$")
+          echo "mnt_exists: ${mnt_exists}"
           if [[ "${mnt_exists}" == "" ]]; then
             echo "/mnt is not mounted, so skipping LVM creation"
             lsblk

--- a/action.yml
+++ b/action.yml
@@ -111,40 +111,41 @@ runs:
           fi
           echo
 
-          # # store owner of $GITHUB_WORKSPACE in case the action deletes it
-          # WORKSPACE_OWNER="$(stat -c '%U:%G' "${GITHUB_WORKSPACE}")"
+          # store owner of $GITHUB_WORKSPACE in case the action deletes it
+          WORKSPACE_OWNER="$(stat -c '%U:%G' "${GITHUB_WORKSPACE}")"
 
-          # # ensure mount path exists before the action
-          # sudo mkdir -p "${BUILD_MOUNT_PATH}"
-          # sudo find "${BUILD_MOUNT_PATH}" -maxdepth 0 ! -empty -exec echo 'WARNING: directory [{}] is not empty, data loss might occur. Content:' \; -exec ls -al "{}" \;
+          # ensure mount path exists before the action
+          sudo mkdir -p "${BUILD_MOUNT_PATH}"
+          sudo find "${BUILD_MOUNT_PATH}" -maxdepth 0 ! -empty -exec echo 'WARNING: directory [{}] is not empty, data loss might occur. Content:' \; -exec ls -al "{}" \;
 
-          # echo "Removing unwanted software... "
-          # if [[ ${{ inputs.remove-dotnet }} == 'true' ]]; then
-          #   sudo rm -rf /usr/share/dotnet
-          # fi
-          # if [[ ${{ inputs.remove-android }} == 'true' ]]; then
-          #   sudo rm -rf /usr/local/lib/android
-          # fi
-          # if [[ ${{ inputs.remove-haskell }} == 'true' ]]; then
-          #   sudo rm -rf /opt/ghc
-          # fi
-          # if [[ ${{ inputs.remove-codeql }} == 'true' ]]; then
-          #   sudo rm -rf /opt/hostedtoolcache/CodeQL
-          # fi
-          # if [[ ${{ inputs.remove-docker-images }} == 'true' ]]; then
-          #   sudo docker image prune --all --force
-          # fi
-          # echo "... done"
+          echo "Removing unwanted software... "
+          if [[ ${{ inputs.remove-dotnet }} == 'true' ]]; then
+            sudo rm -rf /usr/share/dotnet
+          fi
+          if [[ ${{ inputs.remove-android }} == 'true' ]]; then
+            sudo rm -rf /usr/local/lib/android
+          fi
+          if [[ ${{ inputs.remove-haskell }} == 'true' ]]; then
+            sudo rm -rf /opt/ghc
+          fi
+          if [[ ${{ inputs.remove-codeql }} == 'true' ]]; then
+            sudo rm -rf /opt/hostedtoolcache/CodeQL
+          fi
+          if [[ ${{ inputs.remove-docker-images }} == 'true' ]]; then
+            sudo docker image prune --all --force
+          fi
+          echo "... done"
 
           MNT="/mnt"
-          echo -n "Checking if ${MNT} is mounted..."
-          mnt_exists=$(df 2>/dev/null | grep " ${MNT}\$")
-          if [[ -z "${mnt_exists}" ]]; then
+          echo "Checking if ${MNT} is mounted..."
+          df | grep " ${MNT}"
+          if [[ $? -ne 0 ]]; then
             echo "${MNT} is not mounted, so skipping LVM creation"
             lsblk
+            cat /etc/fstab
             exit 0
           else
-            echo " yes"
+            echo "Found ${MNT}"
           fi
 
           VG_NAME=buildvg

--- a/action.yml
+++ b/action.yml
@@ -137,7 +137,7 @@ runs:
           echo "... done"
 
           mnt_exists=$(cat /proc/mounts | cut -f2 -d" " | grep "^/mnt$")
-          if [[ -z "${mnt_exists}" ]]; then
+          if [[ "${mnt_exists}" == "" ]]; then
             echo "/mnt is not mounted, so skipping LVM creation"
             lsblk
             exit 0

--- a/action.yml
+++ b/action.yml
@@ -138,8 +138,10 @@ runs:
 
           MNT="/mnt"
           echo "Checking if ${MNT} is mounted..."
-          df | grep " ${MNT}"
-          if [[ $? -ne 0 ]]; then
+          set +e
+          MNT_EXISTS=$(df 2>/dev/null /mnt | grep " ${MNT}")
+          set -e
+          if [[ -z "${MNT_EXISTS}" ]]; then
             echo "${MNT} is not mounted, so skipping LVM creation"
             lsblk
             cat /etc/fstab

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
           # we want to reuse the temp disk, so first unmount swap and clean the temp disk
           echo "Unmounting and removing swap file."
           sudo swapoff -a
-          sudo rm -f /mnt/swapfile
+          sudo rm -f ${MNT}/swapfile
 
           echo "Creating LVM Volume."
           echo "  Creating LVM PV on root fs."
@@ -169,7 +169,7 @@ runs:
           # create pv on temp disk
           echo "  Creating LVM PV on temp fs."
           TMP_RESERVE_KB=$(expr ${{ inputs.temp-reserve-mb }} \* 1024)
-          TMP_FREE_KB=$(df --block-size=1024 --output=avail /mnt | tail -1)
+          TMP_FREE_KB=$(df --block-size=1024 --output=avail ${MNT} | tail -1)
           TMP_LVM_SIZE_KB=$(expr $TMP_FREE_KB - $TMP_RESERVE_KB)
           TMP_LVM_SIZE_BYTES=$(expr $TMP_LVM_SIZE_KB \* 1024)
           sudo touch "${{ inputs.tmp-pv-loop-path }}" && sudo fallocate -z -l "${TMP_LVM_SIZE_BYTES}" "${{ inputs.tmp-pv-loop-path }}"

--- a/action.yml
+++ b/action.yml
@@ -136,6 +136,13 @@ runs:
           fi
           echo "... done"
 
+          mnt_exists=`cat /proc/mounts | cut -f2 -d" " | grep "^/mnt$"`
+          if [[ -z "$mnt_exists" ]]; then
+            echo "/mnt is not mounted, so skipping LVM creation"
+            lsblk
+            exit 0
+          fi
+
           VG_NAME=buildvg
 
           # github runners have an active swap file in /mnt/swapfile

--- a/action.yml
+++ b/action.yml
@@ -138,16 +138,13 @@ runs:
 
           MNT="/mnt"
           echo "Checking if ${MNT} is mounted..."
-          set +e
-          MNT_EXISTS=$(df 2>/dev/null /mnt | grep " ${MNT}")
-          set -e
-          if [[ -z "${MNT_EXISTS}" ]]; then
+          if mountpoint -q ${MNT}; then
             echo "${MNT} is not mounted, so skipping LVM creation"
             lsblk
             cat /etc/fstab
             exit 0
           else
-            echo "Found ${MNT}"
+            echo "Found mount point ${MNT}, creating LVM volume group"
           fi
 
           VG_NAME=buildvg

--- a/action.yml
+++ b/action.yml
@@ -136,8 +136,8 @@ runs:
           fi
           echo "... done"
 
-          mnt_exists=`cat /proc/mounts | cut -f2 -d" " | grep "^/mnt$"`
-          if [[ -z "$mnt_exists" ]]; then
+          mnt_exists=$(cat /proc/mounts | cut -f2 -d" " | grep "^/mnt$")
+          if [[ -z "${mnt_exists}" ]]; then
             echo "/mnt is not mounted, so skipping LVM creation"
             lsblk
             exit 0

--- a/action.yml
+++ b/action.yml
@@ -111,40 +111,40 @@ runs:
           fi
           echo
 
-          # store owner of $GITHUB_WORKSPACE in case the action deletes it
-          WORKSPACE_OWNER="$(stat -c '%U:%G' "${GITHUB_WORKSPACE}")"
+          # # store owner of $GITHUB_WORKSPACE in case the action deletes it
+          # WORKSPACE_OWNER="$(stat -c '%U:%G' "${GITHUB_WORKSPACE}")"
 
-          # ensure mount path exists before the action
-          sudo mkdir -p "${BUILD_MOUNT_PATH}"
-          sudo find "${BUILD_MOUNT_PATH}" -maxdepth 0 ! -empty -exec echo 'WARNING: directory [{}] is not empty, data loss might occur. Content:' \; -exec ls -al "{}" \;
+          # # ensure mount path exists before the action
+          # sudo mkdir -p "${BUILD_MOUNT_PATH}"
+          # sudo find "${BUILD_MOUNT_PATH}" -maxdepth 0 ! -empty -exec echo 'WARNING: directory [{}] is not empty, data loss might occur. Content:' \; -exec ls -al "{}" \;
 
-          echo "Removing unwanted software... "
-          if [[ ${{ inputs.remove-dotnet }} == 'true' ]]; then
-            sudo rm -rf /usr/share/dotnet
-          fi
-          if [[ ${{ inputs.remove-android }} == 'true' ]]; then
-            sudo rm -rf /usr/local/lib/android
-          fi
-          if [[ ${{ inputs.remove-haskell }} == 'true' ]]; then
-            sudo rm -rf /opt/ghc
-          fi
-          if [[ ${{ inputs.remove-codeql }} == 'true' ]]; then
-            sudo rm -rf /opt/hostedtoolcache/CodeQL
-          fi
-          if [[ ${{ inputs.remove-docker-images }} == 'true' ]]; then
-            sudo docker image prune --all --force
-          fi
-          echo "... done"
+          # echo "Removing unwanted software... "
+          # if [[ ${{ inputs.remove-dotnet }} == 'true' ]]; then
+          #   sudo rm -rf /usr/share/dotnet
+          # fi
+          # if [[ ${{ inputs.remove-android }} == 'true' ]]; then
+          #   sudo rm -rf /usr/local/lib/android
+          # fi
+          # if [[ ${{ inputs.remove-haskell }} == 'true' ]]; then
+          #   sudo rm -rf /opt/ghc
+          # fi
+          # if [[ ${{ inputs.remove-codeql }} == 'true' ]]; then
+          #   sudo rm -rf /opt/hostedtoolcache/CodeQL
+          # fi
+          # if [[ ${{ inputs.remove-docker-images }} == 'true' ]]; then
+          #   sudo docker image prune --all --force
+          # fi
+          # echo "... done"
 
-          echo "Checking if /mnt is mounted..."
-          echo "Mounts:"
-          cat /proc/mounts
-          mnt_exists=$(cat /proc/mounts | cut -f2 -d" " | grep "^/mnt$")
-          echo "mnt_exists: ${mnt_exists}"
-          if [[ "${mnt_exists}" == "" ]]; then
-            echo "/mnt is not mounted, so skipping LVM creation"
+          MNT="/mnt"
+          echo -n "Checking if ${MNT} is mounted..."
+          mnt_exists=$(df 2>/dev/null | grep " ${MNT}\$")
+          if [[ -z "${mnt_exists}" ]]; then
+            echo "${MNT} is not mounted, so skipping LVM creation"
             lsblk
             exit 0
+          else
+            echo " yes"
           fi
 
           VG_NAME=buildvg

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Maximize build disk space'
+name: 'Increase build disk space'
 description: 'Maximize the available disk space for your build job'
 branding:
   icon: 'crop'

--- a/action.yml
+++ b/action.yml
@@ -139,12 +139,12 @@ runs:
           MNT="/mnt"
           echo "Checking if ${MNT} is mounted..."
           if mountpoint -q ${MNT}; then
+            echo "Found mount point ${MNT}, creating LVM volume group"
+          else
             echo "${MNT} is not mounted, so skipping LVM creation"
             lsblk
             cat /etc/fstab
             exit 0
-          else
-            echo "Found mount point ${MNT}, creating LVM volume group"
           fi
 
           VG_NAME=buildvg


### PR DESCRIPTION
I've noticed that some runners don't have /mnt.  They generally have a large / partition, so the lvm trick won't work and isn't needed for these runners.

Even worse, in the current code, this causes the script to miscalculate the appropriate size of the lvm image file, filling the root partition and causing the job to fail.

This PR adds a simple check for the existence of /mnt and skips the LVM creation and setup when /mnt is not present.